### PR TITLE
Node dev and use grunt for deployment

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -52,6 +52,22 @@ module.exports = (grunt) ->
           src: ['**/*.{png,jpg,jpeg,gif}']
           dest: 'tmp/images'
         }]
+    uglify:
+      dev:
+        files: [{
+          expand: true
+          cwd: 'tmp/javascripts/'
+          src: ['**/*.js', '!**/*.min.js']
+          dest: 'tmp/javascripts'
+          ext: '.js'
+        }]
+    cssmin:
+      dev:
+        expand: true
+        cwd: 'tmp/stylesheets/'
+        src: ['**/*.css']
+        dest: 'tmp/stylesheets/'
+        ext: '.css'
     copy:
       assets:
         cwd: 'assets/vendor/'
@@ -83,24 +99,47 @@ module.exports = (grunt) ->
         src: '**/*'
         dest: 'public/images'
         expand: true
-    uglify:
+    exec:
       dev:
-        files: [{
-          expand: true
-          cwd: 'tmp/javascripts/'
-          src: ['**/*.js', '!**/*.min.js']
-          dest: 'tmp/javascripts'
-          ext: '.js'
-        }]
-    cssmin:
-      dev:
-        expand: true
-        cwd: 'tmp/stylesheets/'
-        src: ['**/*.css']
-        dest: 'tmp/stylesheets/'
-        ext: '.css'
+        options:
+          stdout: true
+          stderr: true
+        command: 'node-dev app.coffee'
+      production_start:
+        command: 'pm2 start app.coffee'
+      production_stop:
+        command: 'pm2 stop all'
+      production_reload:
+        comamnd: 'pm2 reload all'
+
 
   require('load-grunt-tasks')(grunt)
+  grunt.loadNpmTasks 'grunt-exec'
 
-  grunt.registerTask 'default', ['clean:pre', 'coffeelint', 'coffee:dev', 'less:dev', 'copy:assets', 'copy:vendor_javascripts', 'copy:vendor_stylesheets', 'uglify:dev', 'cssmin:dev', 'copy:js', 'copy:css', 'clean:post']
+  grunt.registerTask 'production', [
+    'deploy-assets',
+    'exec:production_start'
+  ]
+
+  grunt.registerTask 'deploy-assets', [
+    'clean:pre',
+    'coffeelint',
+    'coffee:dev',
+    'less:dev',
+    'copy:assets',
+    'copy:vendor_javascripts',
+    'copy:vendor_stylesheets',
+    'uglify:dev',
+    'cssmin:dev',
+    'copy:js',
+    'copy:css',
+    'clean:post'
+  ]
+
+  grunt.registerTask 'stop', ['exec:production_stop']
+  grunt.registerTask 'restart', ['exec:production_stop', 'exec:production_start']
+  grunt.registerTask 'reload', ['exec:production_reload']
+
+  grunt.registerTask 'default', ['deploy-assets', 'exec:dev']
+
   grunt.registerTask 'imagecomp', ['imagemin:comp']

--- a/README.md
+++ b/README.md
@@ -13,17 +13,27 @@ Any suggestions or pull-requests are welcomed!
     cd node-express-grunt-boilerplate
     npm install
 
-### Starting Server
+### Development
+    grunt
+
+### Production
+
+#### Starting Server
     npm start
 
-### Stopping Server
-    npm stop
+or
 
-### Restarting server
-    pm2 restart all
+    grunt production
 
-### Zero downtime restart
-    npm run-script reload
+
+#### Stopping Server
+    grunt stop
+
+#### Restarting server
+    grunt restart
+
+#### Zero downtime restart
+    grunt reload
 
 ## Folder Tree
     assets

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "private": true,
   "scripts": {
     "preinstall": "npm install -g coffee-script grunt grunt-cli pm2",
-    "start": "pm2 start app.coffee",
-    "stop": "pm2 stop all",
-    "reload": "pm2 reload all"
+    "start": "grunt production"
   },
   "dependencies": {
     "colors": "*",
@@ -28,6 +26,8 @@
     "grunt-contrib-watch": "*",
     "grunt-contrib-copy": "*",
     "grunt-contrib-imagemin": "*",
-    "grunt-contrib-cssmin": "*"
+    "grunt-contrib-cssmin": "*",
+    "node-dev": "~2.1.4",
+    "grunt-exec": "~0.4.2"
   }
 }


### PR DESCRIPTION
Add node-dev for development
Pull asset related grunt tasks out into a separate grunt task
Add grunt tasks for development and production
Update usage in README
